### PR TITLE
🐛 Add specificity values for dark mode to wormhole popups

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -143,8 +143,4 @@ button:hover svg.icon * {
     background-color: var(--main-color);
     color: var(--alt-color);
   }
-  .pcr-selection {
-    /* needs slight nudge to cover full width with grid col setup */
-    width: 100.1%;
-  }
 }


### PR DESCRIPTION
Before:
![image (2)](https://user-images.githubusercontent.com/706378/71296930-9ef4a880-233e-11ea-9702-c5e4f3ff0003.png)


After:
<img width="361" alt="Screen Shot 2019-12-20 at 3 40 31 PM" src="https://user-images.githubusercontent.com/706378/71297052-19252d00-233f-11ea-914c-f732a4b77a87.png">


