### PR TITLE
🐛 Add save for new palette

### DIFF
--- a/app/controllers/palettes.js
+++ b/app/controllers/palettes.js
@@ -34,7 +34,9 @@ export default class PalettesController extends Controller {
 
   @action
   createNewPalette() {
-    this.store.createRecord('palette', { name: 'Palette' });
+    const newPalette = this.store.createRecord('palette', { name: 'Palette' });
+
+    return newPalette.save();
   }
 
   @action


### PR DESCRIPTION
When you create a new palette, it doesn't save until we add a color or change the name, which will add it to any undo/redo changes in future feature. This should likely save on it's own and be it's own change tracked. 