### PR TITLE
Allow select all in inputs

### DIFF
--- a/app/components/palette-row/index.hbs
+++ b/app/components/palette-row/index.hbs
@@ -15,7 +15,7 @@
           value={{@palette.name}}
           type="text"
           {{did-insert this.insertedNameInput}}
-          {{on "click" (stop-propagation (fn this.onNameInputClick))}}
+          {{on "click" (stop-propagation (noop))}}
           {{on "blur" this.stopEditing}}
           {{on "keypress" this.enterPress}}
           {{on "input" this.updatePaletteName}}

--- a/app/components/palette-row/index.ts
+++ b/app/components/palette-row/index.ts
@@ -262,11 +262,6 @@ export default class PaletteRowComponent extends Component<PaletteRowArgs> {
   }
 
   @action
-  onNameInputClick(): void {
-    // Stub function which uses `stop-propagation` to prevent navigating to palette while clicking to move text cursor
-  }
-
-  @action
   enterPress(event: KeyboardEvent): void {
     if (event.keyCode === 13) {
       this.nameInput.blur();

--- a/electron-app/src/shortcuts.js
+++ b/electron-app/src/shortcuts.js
@@ -52,9 +52,9 @@ function setupMenu(mb, launchPicker, openContrastChecker) {
           {
             label: mb.app.name,
             submenu: [
-              { role: 'about' },
+              { label: 'About Swach', role: 'about' },
               { type: 'separator' },
-              { role: 'quit' }
+              { label: 'Quit Swach', role: 'quit' }
             ]
           }
         ]
@@ -101,7 +101,6 @@ function setupMenu(mb, launchPicker, openContrastChecker) {
         { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
         { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
         { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
-        { type: 'separator' },
         {
           label: 'Select All',
           accelerator: 'CmdOrCtrl+A',

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ember-cli-typescript-blueprints": "^3.0.0",
     "ember-click-outside": "^2.0.0",
     "ember-cognito": "0.12.0",
+    "ember-composable-helpers": "^4.4.1",
     "ember-decorators": "^6.1.1",
     "ember-drag-sort": "^3.0.0",
     "ember-electron": "^3.0.0-beta.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -535,7 +535,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
   integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
 
-"@babel/core@^7.1.6", "@babel/core@^7.12.0", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.3.4", "@babel/core@^7.8.7":
+"@babel/core@^7.0.0", "@babel/core@^7.1.6", "@babel/core@^7.12.0", "@babel/core@^7.12.10", "@babel/core@^7.12.3", "@babel/core@^7.12.9", "@babel/core@^7.3.4", "@babel/core@^7.8.7":
   version "7.12.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.10.tgz#b79a2e1b9f70ed3d84bbfb6d8c4ef825f606bccd"
   integrity sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
@@ -4758,6 +4758,25 @@ broccoli-funnel-reducer@^1.0.0:
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
   integrity sha1-ETZbKnha7JsXlyo234fu8kxcwOo=
 
+broccoli-funnel@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz#6823c73b675ef78fffa7ab800f083e768b51d449"
+  integrity sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==
+  dependencies:
+    array-equal "^1.0.0"
+    blank-object "^1.0.1"
+    broccoli-plugin "^1.3.0"
+    debug "^2.2.0"
+    fast-ordered-set "^1.0.0"
+    fs-tree-diff "^0.5.3"
+    heimdalljs "^0.2.0"
+    minimatch "^3.0.0"
+    mkdirp "^0.5.0"
+    path-posix "^1.0.0"
+    rimraf "^2.4.3"
+    symlink-or-copy "^1.0.0"
+    walk-sync "^0.3.1"
+
 broccoli-funnel@^1.0.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
@@ -7471,6 +7490,16 @@ ember-compatibility-helpers@^1.0.2, ember-compatibility-helpers@^1.1.2, ember-co
     babel-plugin-debug-macros "^0.2.0"
     ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
+
+ember-composable-helpers@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-4.4.1.tgz#968f0ef72731cc300b377c552f36f20881911472"
+  integrity sha512-MVx4KGFL6JzsYfCf9OqLCCnr7DN5tG2jFW9EvosvfgCL7gRdNxLqewR4PWPYA882wetmJ9zvcIEUJhFzZ4deaw==
+  dependencies:
+    "@babel/core" "^7.0.0"
+    broccoli-funnel "2.0.1"
+    ember-cli-babel "^7.11.1"
+    resolve "^1.10.0"
 
 ember-cookies@^0.5.0:
   version "0.5.2"


### PR DESCRIPTION
This PR fixes two bugs with palette name inputs:

- Allows CmdOrCtrl+A to select all text
- Prevents clicking inside a palette name to move the text cursor from navigating to the palette