### PR TITLE
chore(deps): bump ember-simple-auth@7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "ember-resolver": "^11.0.1",
     "ember-set-body-class": "^1.0.2",
     "ember-set-helper": "^3.0.1",
-    "ember-simple-auth": "^7.1.0",
+    "ember-simple-auth": "^7.1.1",
     "ember-sinon-qunit": "^7.5.0",
     "ember-source": "^5.12.0",
     "ember-svg-jar": "^2.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,7 +199,7 @@ importers:
         version: 6.1.0(@babel/core@7.26.0)(ember-source@5.12.0)
       ember-cognito:
         specifier: ^2.0.0
-        version: 2.0.0(@glint/template@1.5.0)(ember-simple-auth@7.1.0)(react-native@0.76.5)(webpack@5.97.1)
+        version: 2.0.0(@glint/template@1.5.0)(ember-simple-auth@7.1.1)(react-native@0.76.5)(webpack@5.97.1)
       ember-composable-helpers:
         specifier: ^5.0.0
         version: 5.0.0
@@ -258,8 +258,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1(@babel/core@7.26.0)
       ember-simple-auth:
-        specifier: ^7.1.0
-        version: 7.1.0(@ember/test-helpers@3.3.1)(@glint/template@1.5.0)(ember-source@5.12.0)
+        specifier: ^7.1.1
+        version: 7.1.1(@ember/test-helpers@3.3.1)(@glint/template@1.5.0)(ember-source@5.12.0)
       ember-sinon-qunit:
         specifier: ^7.5.0
         version: 7.5.0(@babel/core@7.26.0)(ember-source@5.12.0)(qunit@2.22.0)(sinon@17.0.1)
@@ -11471,7 +11471,7 @@ packages:
       - supports-color
     dev: true
 
-  /ember-cognito@2.0.0(@glint/template@1.5.0)(ember-simple-auth@7.1.0)(react-native@0.76.5)(webpack@5.97.1):
+  /ember-cognito@2.0.0(@glint/template@1.5.0)(ember-simple-auth@7.1.1)(react-native@0.76.5)(webpack@5.97.1):
     resolution: {integrity: sha512-sOnKjKfS+ihVwZX+ZPGbqci5SOmXLj6NEoUHeySw7zByGnZn7nanNViZud5a0hcJWbr9Nrz2Ur3Q6aYTgx6fJA==}
     engines: {node: 16.* || >= 18}
     peerDependencies:
@@ -11484,7 +11484,7 @@ packages:
       ember-auto-import: 2.10.0(@glint/template@1.5.0)(webpack@5.97.1)
       ember-cli-babel: 7.26.11
       ember-cli-htmlbars: 6.3.0
-      ember-simple-auth: 7.1.0(@ember/test-helpers@3.3.1)(@glint/template@1.5.0)(ember-source@5.12.0)
+      ember-simple-auth: 7.1.1(@ember/test-helpers@3.3.1)(@glint/template@1.5.0)(ember-source@5.12.0)
     transitivePeerDependencies:
       - '@glint/template'
       - encoding
@@ -11868,8 +11868,8 @@ packages:
       - supports-color
     dev: true
 
-  /ember-simple-auth@7.1.0(@ember/test-helpers@3.3.1)(@glint/template@1.5.0)(ember-source@5.12.0):
-    resolution: {integrity: sha512-hFcje2qSda3Axs5jxsSgaXqoxuwzyspMrganAKm35/rcnExvBD4vXbm/at7W5XvFbSF5UYoEpRUN2VvLpf3EUw==}
+  /ember-simple-auth@7.1.1(@ember/test-helpers@3.3.1)(@glint/template@1.5.0)(ember-source@5.12.0):
+    resolution: {integrity: sha512-76XtSXtn6QhqAcIAx+gPYAADnSCwSlnRzFrGYkzxj3WPRcaW0phMqtjQxQZWreXN3hWwIqWKd+B9Cu+hF2CoOQ==}
     peerDependencies:
       '@ember/test-helpers': '>= 3 || > 2.7'
       ember-source: '>=4.0'


### PR DESCRIPTION
Follow up to #2255. Forgot to update :pensive: 

- Fixes reactivity issue where reading `this.session.isAuthenticated` wouldn't make getters to recompute.